### PR TITLE
Remove dependency on unitree_legged_msgs_gencpp

### DIFF
--- a/unitree_controller/CMakeLists.txt
+++ b/unitree_controller/CMakeLists.txt
@@ -36,7 +36,6 @@ add_library(${PROJECT_NAME}
     src/body.cpp 
 )
 
-add_dependencies(${PROJECT_NAME} unitree_legged_msgs_gencpp)
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES} ${EXTRA_LIBS}

--- a/unitree_legged_control/CMakeLists.txt
+++ b/unitree_legged_control/CMakeLists.txt
@@ -28,5 +28,4 @@ link_directories($(catkin_LIB_DIRS) lib)
 add_library( unitree_legged_control 
     src/joint_controller.cpp
 )
-add_dependencies(${PROJECT_NAME} unitree_legged_msgs_gencpp)
 target_link_libraries(unitree_legged_control ${catkin_LIBRARIES} unitree_joint_control_tool)

--- a/z1_controller/CMakeLists.txt
+++ b/z1_controller/CMakeLists.txt
@@ -32,7 +32,6 @@ add_library(${PROJECT_NAME}
     src/unitreeArm.cpp 
 )
 
-add_dependencies(${PROJECT_NAME} unitree_legged_msgs_gencpp)
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES} ${EXTRA_LIBS}


### PR DESCRIPTION
unitree_legged_msgs_gencpp is a redundant dependency since unitree_legged_msgs is already listed as a dependency. Leaving it in cmake files prevents successful clean builds.