### PR TITLE
[g1_description] Add CMakeLists.txt and package.xml in g1_description

### DIFF
--- a/robots/g1_description/CMakeLists.txt
+++ b/robots/g1_description/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(g1_description)
+
+find_package(catkin REQUIRED COMPONENTS
+    roscpp
+    std_msgs
+)
+
+catkin_package(
+    CATKIN_DEPENDS
+)
+
+include_directories(
+    # include
+    ${Boost_INCLUDE_DIR}
+    ${catkin_INCLUDE_DIRS}
+)

--- a/robots/g1_description/package.xml
+++ b/robots/g1_description/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="2">
+    <name>g1_description</name>
+    <version>0.0.0</version>
+    <description>The g1_description package</description>
+
+    <maintainer email="g1@unitree.cc">unitree</maintainer>
+    <license>BSD</license>
+
+    <buildtool_depend>catkin</buildtool_depend>
+    <depend>roscpp</depend>
+    <depend>std_msgs</depend>
+
+</package>


### PR DESCRIPTION
### This PR makes g1_description a ROS package.
I would like to use g1_description as a ROS package. 
@matheecs Is it OK to use g1_description as a ROS package, or would that go against the development policy?

(cf. https://github.com/jsk-ros-pkg/jsk_robot/pull/1947#issuecomment-4268807612)
